### PR TITLE
Fix issue at jules task

### DIFF
--- a/src/kimi_instruct/service.py
+++ b/src/kimi_instruct/service.py
@@ -4,7 +4,8 @@ HTTP API for the Kimi Instruct project manager
 """
 import asyncio
 import json
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
+from pathlib import Path
 from enum import Enum
 from typing import Dict, Any, List
 
@@ -94,8 +95,12 @@ class KimiService:
         # Dashboard
         self.app.router.add_get('/dashboard', self.dashboard)
         
-        # Static files for dashboard
-        self.app.router.add_static('/', path='static', name='static')
+        # Static files for dashboard (optional during tests)
+        # Only register if the directory exists to avoid startup errors
+        static_dir = Path(__file__).parent / 'static'
+        if static_dir.exists() and static_dir.is_dir():
+            # Serve under /static to avoid conflicting with index route
+            self.app.router.add_static('/static/', path=str(static_dir), name='static')
     
     def setup_cors(self):
         """Setup CORS for web dashboard"""


### PR DESCRIPTION
Make static file registration in Kimi service conditional and serve under `/static/` to prevent startup errors when the directory is missing and avoid route conflicts.

The Kimi service previously failed to start if the `static` directory was not present, which could occur in test environments. This change ensures the service starts correctly by only registering the static route if the directory exists and serves it under a dedicated `/static/` path to prevent conflicts with other routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-87a13e5e-de72-46d4-939f-c24b0f155005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87a13e5e-de72-46d4-939f-c24b0f155005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1211902522154938/1211902553767418) by [Unito](https://www.unito.io)
