### PR TITLE
Revert: fix: exclude unreliable external API tests from default 'npm test' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
-    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest --testPathIgnorePatterns=\\"test/ai-sdk.test.js|kimi-computer/test/ai-sdk.test.js\\"",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
     "test:ai-sdk": "NODE_OPTIONS=--experimental-vm-modules npx jest test/ai-sdk.test.js",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules npx jest --watch"
   },


### PR DESCRIPTION
This PR reverts the commit that attempted to fix the CI by modifying package.json. The change was pushed without a clean history, leading to further CI failures. Merging this will restore the repository to a stable state.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1211902522154938/1211902644062214) by [Unito](https://www.unito.io)
