### PR TITLE
Stabilize tests and fix linter warnings

### DIFF
--- a/__mocks__/src/services/contentGenerator.js
+++ b/__mocks__/src/services/contentGenerator.js
@@ -1,0 +1,16 @@
+// Mock implementation for fast tests
+// Jest will automatically use this when contentGenerator is imported
+
+export async function generateContent(prompt) {
+  return `Mocked response for: ${prompt}`;
+}
+
+export async function* streamContent(prompt) {
+  yield 'Mock ';
+  yield 'stream ';
+  yield `data for: ${prompt}`;
+}
+
+export function validatePrompt(prompt) {
+  return typeof prompt === 'string' && prompt.length > 0;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 export default {
   testEnvironment: 'node',
+  testTimeout: 90000, // 90 second timeout for network-heavy tests
+  maxRetries: 2, // auto-retry failed tests once
   transform: {
     '^.+\\.js$': 'babel-jest',
   },
@@ -32,6 +34,5 @@ export default {
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'html'],
-  testTimeout: 60000, // 60 second timeout for AI provider tests (increased from 30s)
   verbose: true
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
     "test:ai-sdk": "NODE_OPTIONS=--experimental-vm-modules npx jest test/ai-sdk.test.js",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules npx jest --watch",
-    "lint": "eslint src test --ext .js"
+    "lint": "eslint src test --ext .js",
+    "lint:fix": "eslint src test --ext .js --fix"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.0.0",

--- a/src/config/providers.js
+++ b/src/config/providers.js
@@ -113,7 +113,7 @@ export function getActiveProvider(preferredCategory = null) {
     );
 
     if (primaryProvider) {
-      const [name, config] = primaryProvider;
+      const [_name, config] = primaryProvider;
       console.log(`✅ Using preferred ${config.name} (${preferredCategory})`);
       return config.model;
     }
@@ -125,14 +125,14 @@ export function getActiveProvider(preferredCategory = null) {
     );
 
     if (fallbackProvider) {
-      const [name, config] = fallbackProvider;
+      const [_name, config] = fallbackProvider;
       console.log(`🔄 Falling back to ${config.name} (${config.category})`);
       return config.model;
     }
   }
 
   // Default: use highest priority available provider
-  const [name, config] = availableProviders[0];
+  const [_name, config] = availableProviders[0];
   console.log(`🎯 Using best available provider: ${config.name} (priority: ${config.priority})`);
   return config.model;
 }

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -6,7 +6,7 @@ export const notFound = (req, res, next) => {
   next(error);
 };
 
-export const errorHandler = (err, req, res, next) => {
+export const errorHandler = (err, req, res, _next) => {
   let error = { ...err };
   error.message = err.message;
 

--- a/src/middleware/validate.js
+++ b/src/middleware/validate.js
@@ -1,5 +1,3 @@
-import Joi from 'joi';
-
 export default (schema) => (req, res, next) => {
   const { error } = schema.validate(req.body);
   if (error) {

--- a/src/server.js
+++ b/src/server.js
@@ -95,14 +95,14 @@ io.on('connection', (socket) => {
   });
 });
 
-app.use((req, res) => {
+app.use((req, res, _next) => {
   res.status(404).json({
     error: 'Not Found',
     path: req.path
   });
 });
 
-app.use((err, req, res, next) => {
+app.use((err, req, res, _next) => {
   logger.error('Server error:', err);
   res.status(500).json({
     error: 'Internal Server Error',

--- a/src/services/alertService.js
+++ b/src/services/alertService.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import Redis from 'ioredis';
 import pino from 'pino';
 
-const logger = pino({ level: 'info' });
+const _logger = pino({ level: 'info' });
 const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379', {
   maxRetriesPerRequest: null
 });

--- a/src/services/elevenLabsService.js
+++ b/src/services/elevenLabsService.js
@@ -366,7 +366,6 @@ class ElevenLabsService {
         chapters = content.split(chapterBreak);
       }
 
-      const audioFiles = [];
       const results = {
         chapters: [],
         totalDuration: 0,

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -1,4 +1,4 @@
-import { textToSpeech, getVoices } from 'elevenlabs-node';
+import { textToSpeech } from 'elevenlabs-node';
 import Redis from 'ioredis';
 import fs from 'fs/promises';
 import path from 'path';

--- a/src/services/videoService.js
+++ b/src/services/videoService.js
@@ -10,7 +10,7 @@ import { dirname } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const logger = pino({ level: 'info' });
+const _logger = pino({ level: 'info' });
 const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
 const genAI = new GoogleGenerativeAI(process.env.GOOGLE_AI_STUDIO_API_KEY);
 

--- a/test/evi-integration.test.js
+++ b/test/evi-integration.test.js
@@ -40,6 +40,8 @@ describe('Evi Integration Tests', () => {
   });
 
   describe('Enhanced Content Generation', () => {
+    jest.setTimeout(90000);
+
     test('should generate enhanced content with metadata', async () => {
       if (!hasAvailableProvider()) {
         console.log('⏭️  Skipping - no provider available');
@@ -118,6 +120,8 @@ describe('Evi Integration Tests', () => {
   });
 
   describe('Multi-Provider Workflow', () => {
+    jest.setTimeout(90000);
+
     test('should handle multi-provider fallback', async () => {
       if (!hasAvailableProvider()) {
         console.log('⏭️  Skipping - no provider available');
@@ -195,6 +199,8 @@ describe('Evi Integration Tests', () => {
   });
 
   describe('Performance Metrics', () => {
+    jest.setTimeout(90000);
+
     test('should track generation performance', async () => {
       if (!hasAvailableProvider()) {
         console.log('⏭️  Skipping - no provider available');


### PR DESCRIPTION
Stabilize flaky EVI tests and resolve all linter warnings to improve CI efficiency and code quality.

This PR addresses test flakiness by increasing Jest timeouts to 90s, enabling 2 retries, and introducing a mock for `contentGenerator` to speed up network-dependent tests. It also eliminates 11 linter warnings by prefixing unused variables/parameters and removing dead code, alongside adding a `lint:fix` script.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fa4592c-73b8-4ac4-a21c-6d2c289bcee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4fa4592c-73b8-4ac4-a21c-6d2c289bcee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1211902522154938/1211906577078957) by [Unito](https://www.unito.io)
