### PR TITLE
fix: Correct LocalAI Mistral model paths and volume mounts

### DIFF
--- a/docker-compose.localai.yml
+++ b/docker-compose.localai.yml
@@ -14,7 +14,7 @@ services:
       - API_KEY=local-ai-key-optional
     volumes:
       - ./models:/models
-      - ./localai-data:/build/models
+      - ./localai-data:/models/localai-data
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/v1/models"]

--- a/models/hermes-2-pro-mistral.yaml
+++ b/models/hermes-2-pro-mistral.yaml
@@ -1,7 +1,7 @@
 name: hermes-2-pro-mistral
 mmap: true
 parameters:
-  model: huggingface://NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q6_K.gguf
+  model: github:NousResearch/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B.Q6_K.gguf
 
 template:
   chat_message: |


### PR DESCRIPTION
This PR addresses the issue with LocalAI not loading the Mistral model by correcting the volume mount in `docker-compose.localai.yml` and updating the model path in `models/hermes-2-pro-mistral.yaml` to use the `github:` prefix for automatic download.