### PR TITLE
fix: checkout correct fork repository for PR head

### DIFF
--- a/.github/workflows/kimi-review-fix.yml
+++ b/.github/workflows/kimi-review-fix.yml
@@ -53,6 +53,7 @@ jobs:
             core.setOutput('pr_number', String(pr.number));
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_repo', pr.head.repo.full_name);
             core.setOutput('base_ref', pr.base.ref);
 
       - name: Stop when not targeting main
@@ -66,6 +67,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          repository: ${{ steps.pr-context.outputs.head_repo }}
           ref: ${{ steps.pr-context.outputs.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Motivation

- Fix the checkout bug in comment-triggered runs where `head_ref` from a forked PR could be resolved in the base repository, causing wrong branch checkouts or accidental pushes.

### Description

- Export `pr.head.repo.full_name` as `head_repo` in the `Resolve PR context` step and pass `repository: ${{ steps.pr-context.outputs.head_repo }}` to `actions/checkout` so the PR head is checked out from the contributor fork.

### Testing

- Parsed the updated workflow YAML successfully with `python - <<'PY'
import yaml
with open('.github/workflows/kimi-review-fix.yml') as f:
    yaml.safe_load(f)
print('ok')
PY`, which returned `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69866c03e4cc832391ac80cdbf12c5ee)