### PR TITLE
fix(ci): repair malformed workflows blocking pending PR checks

### DIFF
--- a/.github/workflows/framer-governance.yml
+++ b/.github/workflows/framer-governance.yml
@@ -104,9 +104,9 @@ jobs:
               ])
               .addHeading('Dashboard Impact', 3)
               .addRaw(`
-- **SAST Findings**: ${findings.errors + findings.warnings} (was 0)
-- **Critical Issues**: ${findings.errors}
-- **Security Score**: ${findings.errors === 0 ? '✅ Pass' : '❌ Fail'}
+              - **SAST Findings**: ${findings.errors + findings.warnings} (was 0)
+              - **Critical Issues**: ${findings.errors}
+              - **Security Score**: ${findings.errors === 0 ? '✅ Pass' : '❌ Fail'}
               `)
               .write();
 

--- a/.github/workflows/kimi-review-fix.yml
+++ b/.github/workflows/kimi-review-fix.yml
@@ -169,14 +169,15 @@ jobs:
               cp "$FILE" "$FILE.bak"
               
               # Use Python for safe replacement
-              python3 -c "
+              python3 - "$FILE" "$SEARCH" "$REPLACE" <<'PY'
+              import pathlib
               import sys
-              with open('$FILE', 'r') as f:
-                  content = f.read()
-              new_content = content.replace('$SEARCH', '$REPLACE', 1)
-              with open('$FILE', 'w') as f:
-                  f.write(new_content)
-              "
+
+              file_path, search_pattern, replacement_code = sys.argv[1:4]
+              path = pathlib.Path(file_path)
+              content = path.read_text()
+              path.write_text(content.replace(search_pattern, replacement_code, 1))
+              PY
               
               # Check if code file for tests
               if [[ "$FILE" =~ \.(py|js|ts|go|java)$ ]]; then

--- a/.github/workflows/kimi-review-fix.yml
+++ b/.github/workflows/kimi-review-fix.yml
@@ -142,7 +142,7 @@ jobs:
           })
           .then(res => res.json())
           .then(data => {
-            console.log('::set-output name=fixes::' + data.choices[0].message.content);
+            require('fs').appendFileSync(process.env.GITHUB_OUTPUT, `fixes=${data.choices[0].message.content}\n`);
           })
           .catch(err => {
             console.error(err);
@@ -170,13 +170,13 @@ jobs:
               
               # Use Python for safe replacement
               python3 -c "
-import sys
-with open('$FILE', 'r') as f:
-    content = f.read()
-new_content = content.replace('$SEARCH', '$REPLACE', 1)
-with open('$FILE', 'w') as f:
-    f.write(new_content)
-"
+              import sys
+              with open('$FILE', 'r') as f:
+                  content = f.read()
+              new_content = content.replace('$SEARCH', '$REPLACE', 1)
+              with open('$FILE', 'w') as f:
+                  f.write(new_content)
+              "
               
               # Check if code file for tests
               if [[ "$FILE" =~ \.(py|js|ts|go|java)$ ]]; then

--- a/.github/workflows/pr-fix-agent.yml
+++ b/.github/workflows/pr-fix-agent.yml
@@ -109,15 +109,15 @@ jobs:
 
                   prompt = f"""You are a Python expert. Fix these {error_type} errors:
 
-{errors}
+                  {errors}
 
-Provide:
-1. Root cause analysis (2 sentences)
-2. Specific fixes with file paths and code changes
-3. Shell commands to apply fixes
+                  Provide:
+                  1. Root cause analysis (2 sentences)
+                  2. Specific fixes with file paths and code changes
+                  3. Shell commands to apply fixes
 
-Format as JSON:
-{{"fixes": [{{"file": "path", "action": "description", "command": "shell command"}}]}}"""
+                  Format as JSON:
+                  {{"fixes": [{{"file": "path", "action": "description", "command": "shell command"}}]}}"""
 
                   response = ollama.chat(
                       model=model,


### PR DESCRIPTION
### Motivation
- Several GitHub Actions workflows were malformed (YAML block-scalar and deprecated output usage), preventing the runner from parsing/executing them and leaving CI checks stuck pending.
- Restore correct workflow parsing so pipeline jobs can be scheduled and required checks complete.

### Description
- Fixed a malformed embedded Python heredoc in `.github/workflows/pr-fix-agent.yml` by indenting the prompt body so the YAML block scalar remains valid.
- Replaced deprecated `::set-output` usage with writing to `$GITHUB_OUTPUT` and corrected indentation for an inline Python snippet in `.github/workflows/kimi-review-fix.yml` so the `run: |` block parses correctly.
- Fixed indentation inside the JavaScript template literal used by `actions/github-script` in `.github/workflows/framer-governance.yml` so the `.addRaw(...)` string is valid YAML/JS content.

### Testing
- Parsed all workflows with a Python `yaml.safe_load(...)` script and confirmed all workflow files load successfully (result: success).
- Ran `git diff --check` on modified files to ensure no whitespace/syntax issues were introduced (result: success).
- Attempted to run `actionlint` but it was not available in the environment, so that check could not be executed (result: skipped/unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698670249d0883239ade073bbc5e180f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR repairs three malformed GitHub Actions workflows that were preventing CI checks from running.

### Changes Made
- **.github/workflows/pr-fix-agent.yml**: Fixed indentation of an embedded Python heredoc used as a prompt for the Ollama model so the YAML block-scalar parses correctly.
- **.github/workflows/kimi-review-fix.yml**: Replaced deprecated `::set-output` usage by writing to `$GITHUB_OUTPUT` and corrected indentation for an inline Python heredoc/script so the `run: |` block parses correctly.
- **.github/workflows/framer-governance.yml**: Fixed indentation inside the JavaScript template literal passed to `actions/github-script`'s `.addRaw(...)` so the string is valid YAML/JS content.

### Impact
These syntax and indentation fixes restore correct workflow parsing so GitHub Actions can schedule and run pipeline jobs, allowing required CI checks to complete instead of remaining pending.

### Scope / Risks
- No changes to security mechanisms (rate limits, authentication/authorization).
- No changes to database schemas.
- No changes to external API integrations or their authentication — workflows still call the same external services and use existing secrets.
- Changes are structural (YAML/indentation and output mechanism update) only; control flow and error handling remain effectively unchanged.

### Validation
- All workflow files parsed successfully with a yaml.safe_load(...) script.
- `git diff --check` run on modified files showed no whitespace/syntax issues.
- actionlint was unavailable in the environment and therefore not run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->