### PR TITLE
Harden orchestrator pytest subprocess execution

### DIFF
--- a/src/pr_fix_agent/orchestrator.py
+++ b/src/pr_fix_agent/orchestrator.py
@@ -5,6 +5,7 @@ Issue Fixed: Complete LLM-powered code review pipeline
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
@@ -180,9 +181,26 @@ Snippet: {finding.code_snippet}
             Path(fix.file_path).write_text(fix.fixed_code)
 
         try:
+            pytest_cmd = [
+                sys.executable,
+                "-m",
+                "pytest",
+                "tests/",
+                "--json-report",
+                "--json-report-file=test-results.json",
+            ]
+            env = {
+                "PATH": os.environ.get("PATH", ""),
+                "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+            }
             result = subprocess.run(
-                ["pytest", "tests/", "--json-report", "--json-report-file=test-results.json"],
-                cwd=repo_path, capture_output=True, text=True
+                pytest_cmd,
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                shell=False,
+                env=env,
+                check=False,
             )
 
             # Load json report if it exists


### PR DESCRIPTION
### Motivation
- Reduce security and reliability risks from invoking a bare `pytest` executable which can be resolved unpredictably via `PATH` or a partial executable path. 
- Make test execution deterministic when the orchestrator applies fixes and runs the project's test suite.

### Description
- Switched test invocation in `CodeReviewOrchestrator._apply_and_test` to call the interpreter explicitly via `sys.executable -m pytest` instead of `pytest` directly. 
- Added an `os` import and construct `pytest_cmd` list to run `pytest` with `--json-report` output to `test-results.json`. 
- Constrained the subprocess environment to inherit only `PATH` and `PYTHONPATH` from the current process. 
- Made the subprocess invocation explicit and safer by setting `shell=False` and `check=False` and using `capture_output=True, text=True`.

### Testing
- Ran `pytest -q tests/test_main.py tests/test_integration.py tests/test_fixer.py` which failed with `ModuleNotFoundError: No module named 'opik.plugins'` due to an external pytest plugin being loaded. 
- Re-ran with plugin autoload disabled: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_main.py tests/test_integration.py tests/test_fixer.py` which failed with an `IndentationError` in `tests/conftest.py` caused by malformed lines in the test file; these test-suite issues are unrelated to the subprocess changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873cb6f58c8323896106fd5f945492)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Security Hardening in Subprocess Execution

**Security Mechanism Update:**
Modified the `_apply_and_test` method in `CodeReviewOrchestrator` to enhance security and reliability of test execution:

- **Subprocess Invocation**: Switched from direct `pytest` command invocation (vulnerable to PATH resolution unpredictability and potential shell injection) to explicit Python interpreter execution using `sys.executable -m pytest`
- **Environment Constraint**: Restricted subprocess environment to only `PATH` and `PYTHONPATH` variables, preventing unintended environment variable propagation
- **Shell Execution**: Set `shell=False` to eliminate shell processing layer, improving determinism and reducing attack surface
- **Process Handling**: Configured subprocess with `capture_output=True`, `text=True`, and `check=False` for explicit output handling

**No Changes to:**
- Database schemas
- External API integrations
- Authentication or rate limiting mechanisms

The modifications reduce the risk of unpredictable test execution behavior and potential security vulnerabilities from subprocess handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->